### PR TITLE
[LIBFUSE] Fix comparison of integers of different signs

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -1730,7 +1730,7 @@ int fuse_fs_read_buf(struct fuse_fs *fs, const char *path,
 				(unsigned long long) fi->fh,
 				fuse_buf_size(*bufp),
 				(unsigned long long) off);
-		if (res >= 0 && fuse_buf_size(*bufp) > (int) size)
+		if (res >= 0 && fuse_buf_size(*bufp) > size)
 			fprintf(stderr, "fuse: read too many bytes\n");
 
 		if (res < 0)

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -2399,12 +2399,12 @@ static const char *opname(enum fuse_opcode opcode)
 static int fuse_ll_copy_from_pipe(struct fuse_bufvec *dst,
 				  struct fuse_bufvec *src)
 {
-	int res = fuse_buf_copy(dst, src, 0);
+	ssize_t res = fuse_buf_copy(dst, src, 0);
 	if (res < 0) {
 		fprintf(stderr, "fuse: copy from pipe: %s\n", strerror(-res));
 		return res;
 	}
-	if (res < fuse_buf_size(dst)) {
+	if ((size_t)res < fuse_buf_size(dst)) {
 		fprintf(stderr, "fuse: copy from pipe: short read\n");
 		return -1;
 	}
@@ -2940,7 +2940,7 @@ retry:
 		goto out_free;
 	}
 
-	if (ret == bufsize) {
+	if ((size_t)ret == bufsize) {
 		free(buf);
 		bufsize *= 4;
 		goto retry;


### PR DESCRIPTION
Some variables of different size and sign were getting compared
without any safe casting.
The build system also throws warnings at this and, being this
library used for filesystems, it's really important to ensure
stability.